### PR TITLE
Add background color to html tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
 
             html, body {
                 overflow: hidden;
+                background-color: #000;
             }
 
             body {


### PR DESCRIPTION
I use the web site of this on my iPhone 7. When I add it to the Home Screen as a Web App, I have a white status bar at the top.

I notice you have `<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">` on index.html, but I believe you also need to set the `background-color` on the body tag of DOM. The black-translucent setting has white text and symbols, and will take the same background color as the body of your web app.

Love this app!