### PR TITLE
add link to replit run

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npx http-server"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # WebGL Fluid Simulation
 
-[Play here](https://paveldogreat.github.io/WebGL-Fluid-Simulation/)
+[Play here](https://paveldogreat.github.io/WebGL-Fluid-Simulation/) [![run on repl.it](http://repl.it/badge/github/PavelDoGreat/WebGL-Fluid-Simulation)](https://repl.it/github/PavelDoGreat/WebGL-Fluid-Simulation)
+
 
 <img src="/screenshot.jpg?raw=true" width="880">
 


### PR DESCRIPTION
i think it would be pretty cool to let people see how this code works (and edit / preview the program) right in their browser, without any manual downloads or installation. i'm thinking we can add a 'run on repl.it' button, which redirects to something like [this](https://repl.it/@eankeen/run-WebGL-Fluid-Simulation):

![image](https://i.imgur.com/xxXt0kR.png)
