### PR TITLE
listen to window instead of canvas and fix mouse position for window

### DIFF
--- a/script.js
+++ b/script.js
@@ -1470,11 +1470,11 @@ canvas.addEventListener('mousedown', e => {
     updatePointerDownData(pointer, -1, posX, posY);
 });
 
-canvas.addEventListener('mousemove', e => {
-    let pointer = pointers[0];
+window.addEventListener('mousemove', e => {
+    //let pointer = pointers[0];
     if (!pointer.down) return;
-    let posX = scaleByPixelRatio(e.offsetX);
-    let posY = scaleByPixelRatio(e.offsetY);
+    let posX = scaleByPixelRatio(e.clientX);
+    let posY = scaleByPixelRatio(e.clientY);
     updatePointerMoveData(pointer, posX, posY);
 });
 
@@ -1539,8 +1539,8 @@ function updatePointerDownData (pointer, id, posX, posY) {
 function updatePointerMoveData (pointer, posX, posY) {
     pointer.prevTexcoordX = pointer.texcoordX;
     pointer.prevTexcoordY = pointer.texcoordY;
-    pointer.texcoordX = posX / canvas.width;
-    pointer.texcoordY = 1.0 - posY / canvas.height;
+    pointer.texcoordX = posX / (window.width/2);
+    pointer.texcoordY = 1.0 - posY / (window.height/2);
     pointer.deltaX = correctDeltaX(pointer.texcoordX - pointer.prevTexcoordX);
     pointer.deltaY = correctDeltaY(pointer.texcoordY - pointer.prevTexcoordY);
     pointer.moved = Math.abs(pointer.deltaX) > 0 || Math.abs(pointer.deltaY) > 0;


### PR DESCRIPTION
I know many want to use the fluid simulation as a background for their website, but only setting a canvas below the other elements doesn't seem to work perfectly, after changing the CSS so the canvas is below the other elements and is covering the whole screen, here are the changes I made so the javascript works as expected:

1st: listen to mousemove instead of onClick, to do it comment this line : //if (!pointer.down) return;

2nd : listen to window instead of canvas :
-canvas.addEventListener(mousemove, function)
+window.addEventListener(mousemove, function)

Next, on posX and posY change offsetX and offsetY by clientX and clientY:
-let posX = scaleByPixelRatio(e.offsetX);
-let posY = scaleByPixelRatio(e.offsetY);
+let posX = scaleByPixelRatio(e.clientX);
+let posY = scaleByPixelRatio(e.clientY);

Then, you will have to apply some changes to the function ### updatePointerMoveData :

change the canvas.width and height in these two lines :
-pointer.texcoordX = posX / canvas.width;
-pointer.texcoordY = 1.0 - posY / canvas.height;
it should be something like this :
pointer.texcoordX = posX / (canvas.width/2);
pointer.texcoordY = 1 - posY / (canvas.height/2);
This worked for me because I set the canvas size to 100vw and 100vh
these were all the changes I made and it worked fine for me, hope this helps